### PR TITLE
ログインしてない時の遷移先を変更

### DIFF
--- a/routes/admin.php
+++ b/routes/admin.php
@@ -32,22 +32,20 @@ Route::get('/test', TestController::class, 'index');
 
 Route::get('/', function () {
     return view('admin.welcome');
-});
+})->middleware('auth:admin');
 
 Route::resource('students', StudentsController::class)
-->middleware('auth:admin')->except(['show']);
+    ->middleware('auth:admin')->except(['show']);
 
-Route::prefix('expired-students')->
-middleware('auth:admin')->group(function(){
+Route::prefix('expired-students')->middleware('auth:admin')->group(function () {
     Route::get('index', [StudentsController::class, 'expiredStudentIndex'])->name('expired-students.index');
     Route::post('destroy/{student}', [StudentsController::class, 'expiredStudentDestroy'])->name('expired-students.destroy');
 });
 
 Route::resource('teachers', TeachersController::class)
-->middleware('auth:admin');
+    ->middleware('auth:admin');
 
-Route::prefix('expired-teachers')->
-middleware('auth:admin')->group(function(){
+Route::prefix('expired-teachers')->middleware('auth:admin')->group(function () {
     Route::get('index', [TeachersController::class, 'expiredTeacherIndex'])->name('expired-teachers.index');
     Route::post('destroy/{teacher}', [TeachersController::class, 'expiredTeacherDestroy'])->name('expired-teachers.destroy');
 });
@@ -55,9 +53,9 @@ middleware('auth:admin')->group(function(){
 Route::get('/dashboard', function () {
     return view('admin.dashboard');
 })
-//⇓ここで認証してるか確認。
-// auth:adminで、adminの権限を持っていたらダッシュボードが表示
-->middleware(['auth:admin', 'verified'])->name('dashboard');
+    //⇓ここで認証してるか確認。
+    // auth:adminで、adminの権限を持っていたらダッシュボードが表示
+    ->middleware(['auth:admin', 'verified'])->name('dashboard');
 
 Route::middleware('auth:admin')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
@@ -68,47 +66,47 @@ Route::middleware('auth:admin')->group(function () {
 
 Route::middleware('guest')->group(function () {
     Route::get('register', [RegisteredUserController::class, 'create'])
-                ->name('register');
+        ->name('register');
 
     Route::post('register', [RegisteredUserController::class, 'store']);
 
     Route::get('login', [AuthenticatedSessionController::class, 'create'])
-                ->name('login');
+        ->name('login');
 
     Route::post('login', [AuthenticatedSessionController::class, 'store']);
 
     Route::get('forgot-password', [PasswordResetLinkController::class, 'create'])
-                ->name('password.request');
+        ->name('password.request');
 
     Route::post('forgot-password', [PasswordResetLinkController::class, 'store'])
-                ->name('password.email');
+        ->name('password.email');
 
     Route::get('reset-password/{token}', [NewPasswordController::class, 'create'])
-                ->name('password.reset');
+        ->name('password.reset');
 
     Route::post('reset-password', [NewPasswordController::class, 'store'])
-                ->name('password.store');
+        ->name('password.store');
 });
 
 Route::middleware('auth:admin')->group(function () {
     Route::get('verify-email', [EmailVerificationPromptController::class, '__invoke'])
-                ->name('verification.notice');
+        ->name('verification.notice');
 
     Route::get('verify-email/{id}/{hash}', [VerifyEmailController::class, '__invoke'])
-                ->middleware(['signed', 'throttle:6,1'])
-                ->name('verification.verify');
+        ->middleware(['signed', 'throttle:6,1'])
+        ->name('verification.verify');
 
     Route::post('email/verification-notification', [EmailVerificationNotificationController::class, 'store'])
-                ->middleware('throttle:6,1')
-                ->name('verification.send');
+        ->middleware('throttle:6,1')
+        ->name('verification.send');
 
     Route::get('confirm-password', [ConfirmablePasswordController::class, 'show'])
-                ->name('password.confirm');
+        ->name('password.confirm');
 
     Route::post('confirm-password', [ConfirmablePasswordController::class, 'store']);
 
     Route::put('password', [PasswordController::class, 'update'])->name('password.update');
 
     Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])
-                ->name('logout');
+        ->name('logout');
 });

--- a/routes/student.php
+++ b/routes/student.php
@@ -32,7 +32,7 @@ use App\Http\Controllers\Student\TodoController;
 
 Route::get('/', function () {
     return view('student.welcome');
-});
+})->middleware('auth:students');
 
 Route::get('/dashboard', function () {
     return view('student.dashboard');

--- a/routes/teacher.php
+++ b/routes/teacher.php
@@ -32,7 +32,7 @@ use App\Http\Controllers\Teacher\QuestionnaireController;
 
 Route::get('/', function () {
     return view('teacher.welcome');
-});
+})->middleware('auth:teachers');
 
 Route::get('/dashboard', function () {
     return view('teacher.dashboard');


### PR DESCRIPTION
## 関連Issue

<!-- PRと関連しているIssueを紐づけてください -->

## やったこと

未ログイン時に「/student」などとアクセスすると、「/student/login」とログイン画面に遷移されるように。管理者、講師ログインでも一緒。

## 動作確認
あり